### PR TITLE
Clarified licenses and version number

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
-The glossary and contributions to the glossary are licensed under CC-BY-4.0 (full text included here).
+The glossary and contributions to the glossary are licensed under the Creative Commons Attribution-ShareAlike 4.0 International license (CC-BY-SA-4.0; full text included below).
 
-Code contributions to the project are licensed under the BSD 3 Cl Attribution-ShareAlike 4.0 International (full text included by reference)
+Code contributions to the project are licensed under the Apache License, version 2.0 (Apache-2.0, available at: https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 =======================================================================
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [Open Glossary of Edge Computing](./edge-glossary.md) seeks to provide the industry with a concise collection of terms related to the field of edge computing, curating common and accepted definitions into an openly licensed repository. The Open Glossary project uses a community-driven process to develop and improve upon this shared lexicon, offering a vendor-neutral platform with which to discuss compelling solutions offered by edge computing and the next generation Internet.
 
-This Open Glossary is presented under an Apache 2.0 open source license in order to encourage use and adoption. It is purposefully not owned or controlled by any one person, entity or vendor; it a collaborative effort, open to contributions from the entire community.
+This Open Glossary is presented under the Creative Commons Attribution-ShareAlike 4.0 International license (CC-BY-SA-4.0) in order to encourage use and adoption. Code contributions to the project are licensed under the Apache License, version 2.0 (Apache-2.0). It is purposefully not owned or controlled by any one person, entity or vendor; it a collaborative effort, open to contributions from the entire community.
 
 The Open Glossary project is governed in an open, meritocratic fashion. The official version of the Open Glossary is available via a live Github repo. Proposed edits, clarifications and suggestions are made via "pull requests." Each pull request will be evaluated by the community for inclusion.
 

--- a/edge-glossary.md
+++ b/edge-glossary.md
@@ -1,8 +1,8 @@
-# Open Glossary of Edge Computing [v0.8.2-Beta]
+# Open Glossary of Edge Computing [v0.9.0-Beta]
 
 * Version: v0.9.0-beta
 * Date: June 12, 2018 1:28 PM Pacific Time
-* License: Apache 2.0
+* License: Creative Commons Attribution-ShareAlike 4.0 International (CC-BY-SA-4.0)
 
 ## Overview
 


### PR DESCRIPTION
This is to clarify references to the applicable licenses, and to remove references to a couple of licenses that do not apply.

I've also changed the version number in edge-glossary.md to bring it in sync (it previously 0.8.2 in the top line but 0.9.0 further down).